### PR TITLE
Invert texture due to flipped normals

### DIFF
--- a/sphere2cube/blender_init.py
+++ b/sphere2cube/blender_init.py
@@ -10,4 +10,7 @@ sphere = bpy.data.objects["Sphere"]
 sphere.rotation_mode = 'XYZ'
 sphere.rotation_euler = (float(sys.argv[-3]), float(sys.argv[-2]), float(sys.argv[-1]))
 
+bpy.data.meshes["Sphere"].use_auto_texspace = 0
+bpy.data.meshes["Sphere"].texspace_size[0] = -1
+
 bpy.ops.render.render(animation=True)


### PR DESCRIPTION
Since we're capturing the inside of the sphere, the normals are facing the wrong direction. This can be fixed by flipping the texture space of the sphere in the x direction.

Maybe not a problem on all platforms? I'm on OSX 10.9.
