### PR TITLE
Compatibility fix for Blender 2.8.1

### DIFF
--- a/sphere2cube/blender_init.py
+++ b/sphere2cube/blender_init.py
@@ -3,7 +3,7 @@ __author__ = 'Xyene'
 import bpy
 import sys
 
-bpy.data.textures[0].image = bpy.data.images.load("%s" % sys.argv[-6])
+bpy.data.images[1].filepath = "%s" % sys.argv[-6]
 bpy.context.scene.render.resolution_x = bpy.context.scene.render.resolution_y = int(sys.argv[-5])
 
 sphere = bpy.data.objects["Sphere"]


### PR DESCRIPTION
Hi,

Glad to contribute to this project again after a long break.

Today, I was trying out sphere2cube with Blender 2.81a (blender-2.81a-linux-glibc217-x86_64) and it provided me with solid magenta filled outputs instead of having the actual image. I was able to fix it with the linked code change. 

I do not know whether this is a common issue others also experience.